### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,12 +75,12 @@ jobs:
       - # Add support for more platforms with QEMU (optional)
         # https://github.com/docker/setup-qemu-action
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.3.0
+        uses: docker/setup-qemu-action@v3.4.0
       - # https://github.com/docker/setup-buildx-action/issues/57#issuecomment-1059657292
         # https://github.com/docker/buildx/issues/136#issuecomment-550205439
         # docker buildx create --driver-opt env.http_proxy=$http_proxy --driver-opt env.https_proxy=$https_proxy --driver-opt '"env.no_proxy='$no_proxy'"'
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.8.0
+        uses: docker/setup-buildx-action@v3.9.0
         with:
           buildkitd-config: .github/buildkitd.toml
           driver-opts: |


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.9.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.9.0)** on 2025-02-06T13:27:36Z
* **[docker/setup-qemu-action](https://github.com/docker/setup-qemu-action)** published a new release **[v3.4.0](https://github.com/docker/setup-qemu-action/releases/tag/v3.4.0)** on 2025-02-06T13:24:22Z
